### PR TITLE
Fixed default application finding for Catalina

### DIFF
--- a/src/SearchViewController.swift
+++ b/src/SearchViewController.swift
@@ -33,8 +33,13 @@ class SearchViewController: NSViewController, NSTextFieldDelegate,
         let applicationDir = NSSearchPathForDirectoriesInDomains(
             .applicationDirectory, .localDomainMask, true)[0];
         
+        // Catalina moved default applications under a different mask.
+        let systemApplicationDir = NSSearchPathForDirectoriesInDomains(
+            .applicationDirectory, .systemDomainMask, true)[0];
+        
         // appName to dir recursivity key/valye dict
         appDirDict[applicationDir] = true
+        appDirDict[systemApplicationDir] = true
         appDirDict["/System/Library/CoreServices/"] = false
         
         initFileWatch(Array(appDirDict.keys))


### PR DESCRIPTION
I have updated the search dictionary to include the default applications again as a fix for #10 .