### PR TITLE
Scrollable search results

### DIFF
--- a/src/Base.lproj/Search.storyboard
+++ b/src/Base.lproj/Search.storyboard
@@ -1,18 +1,21 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Window Controller-->
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController storyboardIdentifier="SearchWindowController" id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hidesOnDeactivate="YES" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="IQv-IB-iLA" customClass="SearchWindow" customModule="dmenu_mac" customModuleProvider="target">
-                        <windowStyleMask key="styleMask" unifiedTitleAndToolbar="YES"/>
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" animationBehavior="default" id="IQv-IB-iLA" customClass="SearchWindow" customModule="dmenu_mac" customModuleProvider="target">
                         <rect key="contentRect" x="196" y="0.0" width="485" height="25"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="WoP-cW-Qfs"/>
+                        </connections>
                     </window>
                     <connections>
                         <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
@@ -42,12 +45,32 @@
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                 </textFieldCell>
                             </textField>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="pT6-Na-ekE" customClass="ResultsView" customModule="dmenu_mac" customModuleProvider="target">
-                                <rect key="frame" x="168" y="0.0" width="416" height="31"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="31" id="OUr-nH-FXu"/>
-                                </constraints>
-                            </customView>
+                            <scrollView fixedFrame="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="QVh-If-BUC">
+                                <rect key="frame" x="106" y="0.0" width="416" height="31"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <clipView key="contentView" autoresizesSubviews="NO" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="zRh-Jt-rH1">
+                                    <rect key="frame" x="0.0" y="0.0" width="416" height="31"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <view id="5lG-jR-0ih" customClass="ResultsView" customModule="dmenu_mac" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="-3674" width="418" height="31"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <connections>
+                                                <outlet property="scrollView" destination="QVh-If-BUC" id="PXN-Pz-YRx"/>
+                                            </connections>
+                                        </view>
+                                    </subviews>
+                                    <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="uQ2-nO-u0R">
+                                    <rect key="frame" x="-100" y="-100" width="181" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Czm-aK-GgP">
+                                    <rect key="frame" x="-100" y="-100" width="16" height="94"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wei-Zc-XTz">
                                 <rect key="frame" x="592" y="0.0" width="37" height="31"/>
                                 <constraints>
@@ -64,19 +87,15 @@
                             </button>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="wei-Zc-XTz" firstAttribute="leading" secondItem="pT6-Na-ekE" secondAttribute="trailing" constant="8" id="0s3-pX-OuL"/>
                             <constraint firstAttribute="bottom" secondItem="Fjb-7T-x1e" secondAttribute="bottom" id="J9X-bX-kJ0"/>
-                            <constraint firstItem="pT6-Na-ekE" firstAttribute="leading" secondItem="Fjb-7T-x1e" secondAttribute="trailing" constant="8" id="NXQ-e6-90x"/>
-                            <constraint firstItem="pT6-Na-ekE" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="aLM-vb-JdU"/>
                             <constraint firstItem="wei-Zc-XTz" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="jB3-pG-Ztd"/>
                             <constraint firstAttribute="trailing" secondItem="wei-Zc-XTz" secondAttribute="trailing" id="m9l-uc-dgR"/>
-                            <constraint firstAttribute="bottom" secondItem="pT6-Na-ekE" secondAttribute="bottom" id="o3w-og-Osi"/>
                             <constraint firstItem="Fjb-7T-x1e" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="x2n-mW-u0G"/>
                             <constraint firstItem="Fjb-7T-x1e" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="10" id="yFY-Az-NlG"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="resultsText" destination="pT6-Na-ekE" id="J5I-V6-W1T"/>
+                        <outlet property="resultsText" destination="5lG-jR-0ih" id="bRp-pM-yOg"/>
                         <outlet property="searchText" destination="Fjb-7T-x1e" id="dUT-7x-0zh"/>
                     </connections>
                 </viewController>

--- a/src/Base.lproj/Search.storyboard
+++ b/src/Base.lproj/Search.storyboard
@@ -45,8 +45,22 @@
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                 </textFieldCell>
                             </textField>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wei-Zc-XTz">
+                                <rect key="frame" x="592" y="0.0" width="37" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="37" id="Kua-Rf-Dfv"/>
+                                    <constraint firstAttribute="height" constant="31" id="psQ-wL-BWi"/>
+                                </constraints>
+                                <buttonCell key="cell" type="bevel" title="..." bezelStyle="rounded" alignment="center" inset="2" id="Pbg-wo-DSl">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="openSettings:" target="XfG-lQ-9wD" id="8hb-qD-IXV"/>
+                                </connections>
+                            </button>
                             <scrollView fixedFrame="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="QVh-If-BUC">
-                                <rect key="frame" x="106" y="0.0" width="416" height="31"/>
+                                <rect key="frame" x="174" y="0.0" width="416" height="31"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <clipView key="contentView" autoresizesSubviews="NO" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="zRh-Jt-rH1">
                                     <rect key="frame" x="0.0" y="0.0" width="416" height="31"/>
@@ -71,20 +85,6 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wei-Zc-XTz">
-                                <rect key="frame" x="592" y="0.0" width="37" height="31"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="37" id="Kua-Rf-Dfv"/>
-                                    <constraint firstAttribute="height" constant="31" id="psQ-wL-BWi"/>
-                                </constraints>
-                                <buttonCell key="cell" type="bevel" title="..." bezelStyle="rounded" alignment="center" inset="2" id="Pbg-wo-DSl">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="openSettings:" target="XfG-lQ-9wD" id="8hb-qD-IXV"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="Fjb-7T-x1e" secondAttribute="bottom" id="J9X-bX-kJ0"/>

--- a/src/ResultsView.swift
+++ b/src/ResultsView.swift
@@ -85,7 +85,6 @@ class ResultsView: NSView {
         if dirtyWidth {
             frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: textX, height: frame.height);
             dirtyWidth = false
-            print(selectedAppRect)
             scrollView.contentView.scrollToVisible(selectedAppRect)
         }
     }

--- a/src/ResultsView.swift
+++ b/src/ResultsView.swift
@@ -6,8 +6,12 @@
 import Cocoa
 
 class ResultsView: NSView {
+    @IBOutlet fileprivate var scrollView: NSScrollView!
+    
     let rectFillPadding:CGFloat = 5
     var _list = [URL]()
+    
+    var dirtyWidth: Bool = false;
     
     var _selectedAppIndex: Int = 0
     var selectedAppIndex: Int {
@@ -23,6 +27,7 @@ class ResultsView: NSView {
             needsDisplay = true;
         }
     }
+    var selectedAppRect: NSRect = NSRect()
     
     var list: [URL] {
         get {
@@ -58,12 +63,13 @@ class ResultsView: NSView {
             let textY = (frame.height - size.height) / 2
             
             if _selectedAppIndex == i {
-                NSColor.selectedTextBackgroundColor.setFill()
-                __NSRectFill(NSRect(
+                selectedAppRect = NSRect(
                     x: textX - rectFillPadding,
                     y: textY - rectFillPadding,
                     width: size.width + rectFillPadding * 2,
-                    height: size.height + rectFillPadding * 2))
+                    height: size.height + rectFillPadding * 2)
+                NSColor.selectedTextBackgroundColor.setFill()
+                __NSRectFill(selectedAppRect)
             }
             
             appName.draw(in: NSRect(
@@ -75,12 +81,17 @@ class ResultsView: NSView {
                 ])
             
             textX += 10 + size.width;
-            
-            //stop drawing if we passed the visible frame
-            if textX > frame.width {
-                break;
-            }
         }
+        if dirtyWidth {
+            frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: textX, height: frame.height);
+            dirtyWidth = false
+            print(selectedAppRect)
+            scrollView.contentView.scrollToVisible(selectedAppRect)
+        }
+    }
+    
+    func updateWidth() {
+        dirtyWidth = true
     }
 }
 

--- a/src/SearchViewController.swift
+++ b/src/SearchViewController.swift
@@ -192,6 +192,8 @@ class SearchViewController: NSViewController, NSTextFieldDelegate,
         } else {
             self.resultsText.clear()
         }
+        
+        self.resultsText.updateWidth()
     }
     
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
@@ -199,11 +201,13 @@ class SearchViewController: NSViewController, NSTextFieldDelegate,
             if resultsText.selectedAppIndex > 0 {
                 resultsText.selectedAppIndex -= 1
             }
+            resultsText.updateWidth()
             return true
         } else if commandSelector == #selector(moveRight(_:)) {
             if resultsText.selectedAppIndex < resultsText.list.count - 1 {
                 resultsText.selectedAppIndex += 1
             }
+            resultsText.updateWidth()
             return true
         } else if commandSelector == #selector(insertTab(_:)) {
             let list = getStartingBy(searchText.stringValue)

--- a/src/SearchViewController.swift
+++ b/src/SearchViewController.swift
@@ -196,10 +196,14 @@ class SearchViewController: NSViewController, NSTextFieldDelegate,
     
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
         if commandSelector == #selector(moveLeft(_:)) {
-            resultsText.selectedAppIndex -= 1
+            if resultsText.selectedAppIndex > 0 {
+                resultsText.selectedAppIndex -= 1
+            }
             return true
         } else if commandSelector == #selector(moveRight(_:)) {
-            resultsText.selectedAppIndex += 1
+            if resultsText.selectedAppIndex < resultsText.list.count - 1 {
+                resultsText.selectedAppIndex += 1
+            }
             return true
         } else if commandSelector == #selector(insertTab(_:)) {
             let list = getStartingBy(searchText.stringValue)


### PR DESCRIPTION
When viewing search results, only what can fit on the screen is displayed and furthermore the selection index has no bounds to it, thus the following can occur:

![Before](https://i.imgur.com/e8osymj.gif)

I've put ResultsView inside of an NSScrollView so that we can now scroll past this barrier until the true last element.

![After](https://i.imgur.com/FGjhym7.gif)