### PR TITLE
feat: add tabbing support

### DIFF
--- a/dmenu-mac.xcodeproj/project.pbxproj
+++ b/dmenu-mac.xcodeproj/project.pbxproj
@@ -40,7 +40,6 @@
 		7F3279071C71DF2300AFB227 /* DDHotKeyUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DDHotKeyUtilities.m; path = "src/3rd-party/DDHotKeyUtilities.m"; sourceTree = "<group>"; };
 		7F32790D1C71DF3E00AFB227 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		7F3279111C71E02300AFB227 /* BridgingHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BridgingHeader.h; path = src/BridgingHeader.h; sourceTree = "<group>"; };
-		7F37938C241FEDF000B82F4E /* Entitlements.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Entitlements.plist; sourceTree = "<group>"; };
 		7F5D0E241CACCD0100268983 /* ResultsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResultsView.swift; path = src/ResultsView.swift; sourceTree = "<group>"; };
 		7F5D0E291CACCDD400268983 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = src/Base.lproj/Empty.storyboard; sourceTree = "<group>"; };
 		7F5D0E2B1CACCDD400268983 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = src/Base.lproj/Settings.storyboard; sourceTree = "<group>"; };
@@ -160,7 +159,7 @@
 			attributes = {
 				CLASSPREFIX = "";
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 1120;
+				LastUpgradeCheck = 1220;
 				ORGANIZATIONNAME = "Jose Pereira";
 				TargetAttributes = {
 					7FE8A6471C717481000A2C4C = {
@@ -272,6 +271,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -344,6 +344,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/dmenu-mac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dmenu-mac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Fuse",
+        "repositoryURL": "https://github.com/krisk/fuse-swift",
+        "state": {
+          "branch": "master",
+          "revision": "26ba868691b2d8b7bf2b1322951eb591be70ccca",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/dmenu-mac.xcodeproj/xcshareddata/xcschemes/dmenu-mac.xcscheme
+++ b/dmenu-mac.xcodeproj/xcshareddata/xcschemes/dmenu-mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/src/Base.lproj/Search.storyboard
+++ b/src/Base.lproj/Search.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -62,7 +62,7 @@
                             <scrollView fixedFrame="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="QVh-If-BUC">
                                 <rect key="frame" x="174" y="0.0" width="416" height="31"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <clipView key="contentView" autoresizesSubviews="NO" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="zRh-Jt-rH1">
+                                <clipView key="contentView" autoresizesSubviews="NO" drawsBackground="NO" copiesOnScroll="NO" id="zRh-Jt-rH1">
                                     <rect key="frame" x="0.0" y="0.0" width="416" height="31"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>

--- a/src/SearchViewController.swift
+++ b/src/SearchViewController.swift
@@ -198,26 +198,16 @@ class SearchViewController: NSViewController, NSTextFieldDelegate,
     }
     
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-        if commandSelector == #selector(moveLeft(_:)) {
-            if resultsText.selectedAppIndex > 0 {
-                resultsText.selectedAppIndex -= 1
-            }
+        let movingLeft:Bool = commandSelector == #selector(moveLeft(_:)) || commandSelector == #selector(insertBacktab(_:))
+        let movingRight:Bool = commandSelector == #selector(moveRight(_:)) || commandSelector == #selector(insertTab(_:))
+        
+        if movingLeft {
+            resultsText.selectedAppIndex = resultsText.selectedAppIndex == 0 ? resultsText.list.count - 1 : resultsText.selectedAppIndex - 1
             resultsText.updateWidth()
             return true
-        } else if commandSelector == #selector(moveRight(_:)) {
-            if resultsText.selectedAppIndex < resultsText.list.count - 1 {
-                resultsText.selectedAppIndex += 1
-            }
+        } else if movingRight {
+            resultsText.selectedAppIndex = (resultsText.selectedAppIndex + 1) % resultsText.list.count
             resultsText.updateWidth()
-            return true
-        } else if commandSelector == #selector(insertTab(_:)) {
-            let list = getStartingBy(searchText.stringValue)
-            if !list.isEmpty {
-                resultsText.list = list
-            } else {
-                resultsText.clear()
-            }
-            
             return true
         } else if commandSelector == #selector(insertNewline(_:)) {
             //open current selected app


### PR DESCRIPTION
### What

Added Tab / Shift-Tab support for quickly browsing through result list

### How

Removed previous tab behaviour (which was clearing the list on unexpected occasions) and added support for tab / shift-tab selectors.

### Note

I'm not proficient in mac os app development, I mostly work on web development, so if I'm committing anything I shouldn't, please say so :-) 

Also, thanks for doing this *d-menu* port, it's good to have a quick and simple alternative to Spotlight!