### PR TITLE
only python3 in MacOS, python2 also EOL

### DIFF
--- a/scripts/dmenu-mac
+++ b/scripts/dmenu-mac
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-function realpath() { python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
+function realpath() { python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
 CONTENTS="$(dirname "$(dirname "$(realpath "$0")")")"
 DMENU_MAC="$CONTENTS/MacOS/dmenu-mac"
 "$DMENU_MAC" "$@"


### PR DESCRIPTION
On macOS 13 python is not available as application.
Also Python2 is EOL and should not be used anymore.