### PR TITLE
feat: add exit flag to allow for exiting after selection is made

### DIFF
--- a/src/AppListProvider.swift
+++ b/src/AppListProvider.swift
@@ -26,8 +26,12 @@ class AppListProvider: ListProvider {
     var appDirDict = [String: Bool]()
 
     var appList = [URL]()
+    
+    let exitFlag: Bool
 
-    init() {
+    init(exitFlag: Bool) {
+        self.exitFlag = exitFlag
+        
         let applicationDir = NSSearchPathForDirectoriesInDomains(
             .applicationDirectory, .localDomainMask, true)[0]
 
@@ -41,7 +45,7 @@ class AppListProvider: ListProvider {
         appDirDict["/System/Library/CoreServices/"] = false
 
         initFileWatch(Array(appDirDict.keys))
-        updateAppList()
+        updateAppList()        
     }
 
     func initFileWatch(_ dirs: [String]) {
@@ -93,8 +97,12 @@ class AppListProvider: ListProvider {
             NSLog("Cannot do action on item \(item.name)")
             return
         }
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
             NSWorkspace.shared.launchApplication(app.path)
+            
+            if self?.exitFlag ?? false {
+                NSApplication.shared.terminate(self)
+            }
         }
     }
 }

--- a/src/CommandArguments.swift
+++ b/src/CommandArguments.swift
@@ -19,4 +19,7 @@ import ArgumentParser
 struct DmenuMac: ParsableArguments {
     @Option(name: .shortAndLong, help: "Show a prompt instead of the search input.")
     var prompt: String?
+    
+    @Flag(name: .shortAndLong, help: "Exit the process after an item is selected.")
+    var exit: Bool = false
 }

--- a/src/SearchViewController.swift
+++ b/src/SearchViewController.swift
@@ -30,6 +30,7 @@ class SearchViewController: NSViewController, NSTextFieldDelegate,
     var hotkey: DDHotKey?
     var listProvider: ListProvider?
     var promptValue = ""
+    var exitFlag = false
 
     struct Shortcut {
         let keycode: UInt16
@@ -55,16 +56,16 @@ class SearchViewController: NSViewController, NSTextFieldDelegate,
             object: nil
         )
 
+        let options = DmenuMac.parseOrExit()
+        if options.prompt != nil {
+            promptValue = options.prompt!
+        }
+        
         let stdinStr = ReadStdin.read()
         if stdinStr.count > 0 {
             listProvider = PipeListProvider(str: stdinStr)
         } else {
-            listProvider = AppListProvider()
-        }
-
-        let options = DmenuMac.parseOrExit()
-        if options.prompt != nil {
-            promptValue = options.prompt!
+            listProvider = AppListProvider(exitFlag: options.exit ?? false)
         }
 
         clearFields()
@@ -207,9 +208,7 @@ Ensure you are using a unique, valid shortcut.
 
     func closeApp() {
         clearFields()
-        if promptValue == "" {
-            NSApplication.shared.hide(nil)
-        }
+        NSApplication.shared.hide(nil)
     }
 
     @IBAction func openSettings(_ sender: AnyObject) {


### PR DESCRIPTION
Resolves #37

This adds a new flag (`-e` or `--exit`) that exits the process after a selection is made when `dmenu-mac` is launched without arguments.