### PR TITLE
Don't use python to check realpath of symlink

### DIFF
--- a/scripts/dmenu-mac
+++ b/scripts/dmenu-mac
@@ -1,6 +1,5 @@
-#!/usr/bin/env bash
-#
-function realpath() { python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
-CONTENTS="$(dirname "$(dirname "$(realpath "$0")")")"
+#!/bin/sh
+
+CONTENTS=$(readlink -f symlinkName "$0" | xargs dirname | xargs dirname)
 DMENU_MAC="$CONTENTS/MacOS/dmenu-mac"
 "$DMENU_MAC" "$@"


### PR DESCRIPTION
Hi,
I was trying to use the application through the CLI but I was presented with this error:
```
  File "<string>", line 1
    import
          ^
SyntaxError: invalid syntax
/usr/local/bin/dmenu-mac: line 6: ./MacOS/dmenu-mac: No such file or directory
```

After looking at the script I figure to make three changes:
1. Use `readlink` to read the symlink path
2. Use two `xargs` instead of two sub-shells
3. Make it a POSIX script instead of a bash script 